### PR TITLE
document missing ome channel in conda installation cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A conda package for BatchConvert exists: https://anaconda.org/Euro-BioImaging/ba
 
 Conda installation of BatchConvert to a new conda environment is recommended. Simply run the following command:
 
-`conda install -c euro-bioimaging -c conda-forge -c bioconda batchconvert`
+`conda install -c euro-bioimaging -c conda-forge -c bioconda -c ome batchconvert`
 
 ### Installation from the source
 


### PR DESCRIPTION
Calling `conda install -c euro-bioimaging -c conda-forge -c bioconda batchconvert` as described in the README and preprint, I got the following error on mac (using miniconda).

![image](https://github.com/user-attachments/assets/515c1a61-630b-40a7-a4c1-2d592abae406)

Adding the ome channel fixes it 😉