### PR TITLE
Use explicit channels for Nextflow install

### DIFF
--- a/installation/install_with_nextflow.sh
+++ b/installation/install_with_nextflow.sh
@@ -11,8 +11,8 @@ chmod -R 777 $SCRIPTPATH;
 
 cd $SCRIPTPATH;
 
-conda create --yes --name nflow python=3.9 && \
-conda install --yes -n nflow -c bioconda nextflow==23.10.1 && \
+conda create --yes --name nflow -c conda-forge python=3.9 && \
+conda install --yes -n nflow -c conda-forge -c bioconda nextflow==23.10.1 && \
 mv nextflow.sample nextflow
 cd -
 


### PR DESCRIPTION
Fresh GitHub Codespaces can have no Conda channels configured. Therefore `install_with_nextflow.sh`fails with:

```text
NoChannelsConfiguredError: No channels are configured. Conda requires at least one channel to search for packages.

You have attempted to install: python
